### PR TITLE
Adds openapi documentation

### DIFF
--- a/lib/ex_change_web/controllers/fallback_controller.ex
+++ b/lib/ex_change_web/controllers/fallback_controller.ex
@@ -3,7 +3,7 @@ defmodule ExChangeWeb.FallbackController do
 
   def call(conn, {:error, reason}) do
     conn
-    |> put_status(:unprocessable_entity)
+    |> put_status(:bad_request)
     |> put_view(ExChangeWeb.ErrorView)
     |> render("error.json", errors: reason)
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,67 @@
+openapi: "3.0.2"
+info:
+  title: ExChange API
+  description: An API to convert values between pairs of currencies
+  version: "1.0"
+servers:
+  - url: http://localhost:4000/api/
+paths:
+  /convert/{value}/{current}/{target}:
+    get:
+      summary: Converts the given value from current to target currency
+      description: Returns the value converted to the target currency, and the time the exchange rate was updated
+      parameters:
+        - in: path
+          name: value
+          description: Value of the amount being converted
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: current
+          description: Symbol of the currency being converted
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: target
+          description: Symbol of the target currency
+          schema:
+            type: string
+          required: true
+      responses:
+        "200":
+          description: Conversion response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Conversion"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: string
+
+        "500":
+          description: Internal Server Error
+
+components:
+  schemas:
+    Conversion:
+      type: object
+      required:
+        - conversion_info
+      properties:
+        conversion_info:
+          type: object
+          properties:
+            converted_at:
+              type: string
+            converted_value:
+              type: number
+              format: double
+              minimum: 0

--- a/test/ex_change_web/controllers/converter_controller_test.exs
+++ b/test/ex_change_web/controllers/converter_controller_test.exs
@@ -27,9 +27,9 @@ defmodule ExChangeWeb.ConverterControllerTest do
   test "GET /api/convert when conversion fails", %{conn: conn} do
     path_params = %{"current" => "EUR", "target" => "USD", "value" => "10"}
 
-    with_mock ExChange, convert: fn ^path_params -> {:error, ["some reason"]} end do
+    with_mock ExChange, convert: fn ^path_params -> {:error, "some reason"} end do
       conn = get(conn, "/api/convert/10/EUR/USD")
-      assert json_response(conn, 422) == %{"errors" => ["some reason"]}
+      assert json_response(conn, 400) == %{"errors" => "some reason"}
       assert_called(ExChange.convert(:_))
     end
   end


### PR DESCRIPTION
**Why was this change necessary?**

To have the ExChange `convert` endpoint documented

**How does this address the issue?**

Documents the `convert` endpoint using OpenAPI 3.0